### PR TITLE
save over old files + save multiple copies

### DIFF
--- a/src/cloudcasting_app/data.py
+++ b/src/cloudcasting_app/data.py
@@ -105,7 +105,7 @@ def download_all_sat_data() -> bool:
 
     # download 5 minute satellite data
     sat_5_dl_path = os.environ["SATELLITE_ZARR_PATH"]
-    fs = fsspec.open(sat_5_dl_path).fs
+    fs, _ = fsspec.core.url_to_fs(sat_5_dl_path)
     if fs.exists(sat_5_dl_path):
         sat_available = True
         logger.info(f"Downloading 5-minute satellite data")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -14,15 +14,21 @@ def test_app(sat_5_data, tmp_path, test_t0):
     # In production sat zarr is zipped
     os.environ["SATELLITE_ZARR_PATH"] = "temp_sat.zarr.zip"
 
-    os.environ["OUTPUT_PREDICTION_ZARR_PATH"] = "sat_prediction.zarr"
+    os.environ["OUTPUT_PREDICTION_DIRECTORY"] = f"{tmp_path}"
 
     with zarr.storage.ZipStore("temp_sat.zarr.zip", mode="x") as store:
         sat_5_data.to_zarr(store)    
 
     app()
-
+    
+    # Check the two output files have been created
+    latest_zarr_path = f"{tmp_path}/latest.zarr"
+    t0_string_zarr_path = test_t0.strftime(f"{tmp_path}/%Y-%m-%dT%H:%M.zarr")
+    assert os.path.exists(latest_zarr_path)
+    assert os.path.exists(t0_string_zarr_path)
+    
     # Load the predictions and check them
-    ds_y_hat = xr.open_zarr(os.environ["OUTPUT_PREDICTION_ZARR_PATH"])
+    ds_y_hat = xr.open_zarr(latest_zarr_path)
     
     assert "sat_pred" in  ds_y_hat
     assert (


### PR DESCRIPTION
# Pull Request

## Description

- Removes old file paths so they can be overwritten when the app is run
- Saves the predictions twice. As latest.zarr and as [timestamp].zarr


Fixes #7 

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
