### PR TITLE
fix(packaging): Correctly build package for versioning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,17 @@
-# Use an official Python runtime as a parent image
-FROM python:3.11-slim as base
+FROM python:3.11-slim
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
-RUN apt-get update
-RUN apt-get install unzip -y
-RUN apt-get install -y --no-install-recommends git && \
+RUN apt-get update -y && \
+    apt-get -y --no-install-recommends install git unzip build-essential && \
     rm -rf /var/lib/apt/lists/*
 
-# Copy the application files
-COPY src /app/src
-COPY pyproject.toml app/pyproject.toml
-COPY README.md app/README.md
+# Add repository code
+WORKDIR /opt/app
+COPY src /opt/app/src
+COPY pyproject.toml /opt/app
+COPY .git /opt/app/.git
 
-# Set the working directory in the container
-WORKDIR /app
+RUN uv sync --no-dev
 
-# Copy the requirements file and install
-RUN pip install -e .
-
-# Set the entrypoint command to run the app
-CMD ["python", "src/cloudcasting_app/app.py"]
+ENTRYPOINT ["uv", "run", "--no-dev"]
+CMD ["cloudcasting-app"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,20 +20,21 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
 ]
 dependencies = [
-    "torch[cpu]",
-    "fsspec",
-    "s3fs",
-    "xarray",
-    "zarr<3.0",
-    "numpy",
-    "pandas",
-    "typer",
-    "huggingface-hub",
-    "ocf_blosc2",
-    "hydra-core",
-    "safetensors",
-    "ocf-data-sampler",
+    "fsspec==2024.6.1",
+    "huggingface-hub==0.28.1",
+    "hydra-core==1.3.2",
+    "numpy==2.1.2",
+    "ocf-data-sampler==0.1.4",
+    "ocf_blosc2==0.0.13",
+    "pandas==2.2.3",
+    "s3fs==2024.6.1",
+    "safetensors==0.5.2",
     "sat_pred @ git+https://github.com/openclimatefix/sat_pred.git@main",
+    "torch>1.13,<2.3; sys_platform == 'darwin' and platform_machine == 'x86_64'",
+    "torch>=2.3; sys_platform != 'darwin' or platform_machine != 'x86_64'",
+    "typer==0.15.1",
+    "xarray==2025.1.2",
+    "zarr==2.18.3",
 ]
 
 [dependency-groups]
@@ -48,6 +49,7 @@ dev = [
 
 [project.scripts]
 # Put entrypoints in here
+cloudcasting-app = "cloudcasting_app.app:main"
 
 [project.urls]
 repository = "https://github.com/openclimatefix/cloudcasting-app"
@@ -128,3 +130,9 @@ theme = "classic"
 privacy = [
     "HIDDEN:**.test_*",
 ]
+
+[[tool.uv.index]]
+url = "https://pypi.org/simple"
+
+[[tool.uv.index]]
+url = "https://download.pytorch.org/whl/cpu"

--- a/src/cloudcasting_app/__init__.py
+++ b/src/cloudcasting_app/__init__.py
@@ -1,2 +1,0 @@
-"""cloudcasting app"""
-__version__ = "0.0.1"

--- a/src/cloudcasting_app/app.py
+++ b/src/cloudcasting_app/app.py
@@ -25,7 +25,7 @@ from cloudcasting_app.data import prepare_satellite_data, sat_path, get_input_da
 
 # Get package version
 try:
-    __version__ = version("cloudcasting_app")
+    __version__ = version("cloudcasting-app")
 except PackageNotFoundError:
     __version__ = "v?"
 
@@ -153,5 +153,9 @@ def app(t0=None):
         ds_y_hat.to_zarr(path)
     
     
-if __name__ == "__main__":
+def main() -> None:
+    """Entrypoint to the application."""
     typer.run(app)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #11 

Actually gets the version number correctly by specifying the project name as it occurs in `pyproject.toml` to pull the version, as opposed to the name of the package. Also pins torch according to the environment, and includes the version in the built vresion tag.