### PR TITLE
[ENH] Ensure CPU-only PyTorch Installation by Updating `pyproject.toml` and `Dockerfile`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY src /opt/app/src
 COPY pyproject.toml /opt/app
 COPY .git /opt/app/.git
 
-RUN uv sync --no-dev
+RUN uv sync --no-dev --index-strategy unsafe-best-match
 
 ENV _TYPER_STANDARD_TRACEBACK=1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "safetensors==0.5.2",
     "sat_pred @ git+https://github.com/openclimatefix/sat_pred.git@main",
     "torch>1.13,<2.3; sys_platform == 'darwin' and platform_machine == 'x86_64'",
-    "torch>=2.3; sys_platform != 'darwin' or platform_machine != 'x86_64'",
+    "torch==2.3.0+cpu; sys_platform != 'darwin' or platform_machine != 'x86_64'",
     "typer==0.15.1",
     "xarray==2025.1.2",
     "zarr==2.18.3",


### PR DESCRIPTION
Fixes #9

## Description

This PR updates the **`pyproject.toml`** and **`Dockerfile`** to ensure that only the **CPU version of PyTorch** is installed, preventing unintended CUDA dependencies.  

## Changes Made  
**`pyproject.toml`**  
  - Explicitly specified the CPU version of PyTorch.  
  - Adjusted dependency constraints to avoid GPU-related versions.  

**`Dockerfile`**  
  - Added `--index-strategy unsafe-best-match` to `uv sync` to resolve dependency resolution issues.  
  - As `torch` is installed from trusted package sources (PyPI), I think it should be fine to use `--index-strategy unsafe-best-match` 

## How Has This Been Tested?

I have tested installation by developing docker image in my local machine, I have attached the screenshot of it
<br>

![Screenshot 2025-02-24 220612](https://github.com/user-attachments/assets/629946ea-43cb-4718-8889-632a2fa8e12a)


## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
