### PR TITLE
Save 0-deg predictions to different path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "hydra-core==1.3.2",
     "loguru == 0.7.3",
     "numpy==2.1.2",
-    "ocf-data-sampler==0.5.5",
+    "ocf-data-sampler==0.5.27",
     "pandas==2.2.3",
     "s3fs==2025.7.0",
     "safetensors==0.5.2",

--- a/src/cloudcasting_app/data.py
+++ b/src/cloudcasting_app/data.py
@@ -119,11 +119,6 @@ class SatelliteDownloader:
         # Reshape to (channel, time, height, width)
         ds = ds.transpose("variable", "time", "y_geostationary", "x_geostationary")
 
-        # Scale the satellite data from 0-1
-        scale_factor = int(os.environ.get("SATELLITE_SCALE_FACTOR", 1023))
-        logger.info(f"Scaling satellite data by {scale_factor} to be between 0 and 1")
-        ds = ds / scale_factor
-
         # Resave
         ds.to_zarr(sat_path)
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -32,8 +32,8 @@ def test_app(sat_5_data, tmp_path, test_t0):
 
     assert "sat_pred" in  ds_y_hat
     assert (
-        sorted(list(ds_y_hat.sat_pred.coords))==
-        ["init_time", "step", "variable", "x_geostationary", "y_geostationary"]
+        list(ds_y_hat.sat_pred.dims)==
+        ["init_time", "variable", "step", "y_geostationary", "x_geostationary"]
     )
 
     # Make sure all the coords are correct


### PR DESCRIPTION
# Pull Request

## Description

This PR changes the path of where we save the satellite predictions when we are running on the 0-degree satellite. 

This will make it easier to control the behaviour PVNet+cloudcasting when the RS is down.

- To make this PR easier I have refactored the satellite download and tidied up some things
- Also remove satellite scaling since this is no longer used

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
